### PR TITLE
Changed the open function from binary to text

### DIFF
--- a/ietf
+++ b/ietf
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.8
+#!/usr/bin/env python3
 from __future__ import print_function
 import glob, json, subprocess, time, optparse, fnmatch, cmd, os, re
 from xml.etree import ElementTree

--- a/ietf
+++ b/ietf
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.8
 from __future__ import print_function
 import glob, json, subprocess, time, optparse, fnmatch, cmd, os, re
 from xml.etree import ElementTree
@@ -751,7 +751,7 @@ def Cmd_mirror(Args):
 				for ThisFoundInnerAuthor in ThisFoundOuterAuthor.findall(TagBase + "name"):
 					RFCStatus[ThisRFCNum]["authors"].append(ThisFoundInnerAuthor.text)
 	try:
-		with open(RFCStatusFileLoc, mode="wb") as statusf:
+		with open(RFCStatusFileLoc, mode="w") as statusf:
 			json.dump(RFCStatus, statusf)
 	except:
 		exit("Could not dump status info to '" + RFCStatusFileLoc + "'. Exiting.")
@@ -783,7 +783,7 @@ def Cmd_mirror(Args):
 			"title": TheFields[13], \
 			"authors": TheFields[14].rstrip() }
 	try:
-		with open(IDStatusFileLoc, mode="wb") as statusf:
+		with open(IDStatusFileLoc, mode="w") as statusf:
 			json.dump(IDStatus, statusf)
 	except:
 		exit("Could not dump status info to '" + IDStatusFileLoc + "'. Exiting.")	


### PR DESCRIPTION
I experienced the below issue:

    Making the RFC status index 
    Could not dump status info to '/var/db/ietf-mirrors/in-notes/ietf-rfc-status.json'. Exiting. 

This solves the problem.